### PR TITLE
Corrects typo in argument help

### DIFF
--- a/core/lib/error.py
+++ b/core/lib/error.py
@@ -178,7 +178,7 @@ class OSCError(Exception):
                 'table while OSC is running. '
                 '2. some columns have changed their output format, '
                 'for example int -> decimal. '
-                'see also: --skip-checksum-for-modifed '
+                'see also: --skip-checksum-for-modified '
                 '3. it is a bug in OSC'
             ),
         },


### PR DESCRIPTION
When you are changing a columns type, say from int to bigint, you need to pass the `--skip-checksum-for-modified` flag. 

If you don't pass this flag the help text after executing the OSC Copy has a typo in the flag that you need to pass.

It prints:
````
ERROR     2018-09-25 16:52:23.740 CHECKSUM_MISMATCH: Checksum mismatch between origin table and intermediate table. This means one of these: 1. you have some scripts running DDL against the origin table while OSC is running. 2. some columns have changed their output format, for example int -> decimal. see also: --skip-checksum-for-modifed 3. it is a bug in OSC
````

This PR changes the help text from `--skip-checksum-for-modifed` to `--skip-checksum-for-modified`